### PR TITLE
desktop: Disambiguate Name and Comment

### DIFF
--- a/data/bluetooth-daemon.desktop
+++ b/data/bluetooth-daemon.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
-Name=Bluetooth
-Comment=Bluetooth obex
+Name=Bluetooth Daemon
+Comment=Send and receive files via bluetooth
 Exec=io.elementary.bluetooth -s
 Icon=io.elementary.bluetooth
 Type=Application

--- a/data/bluetooth.desktop
+++ b/data/bluetooth.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
-Name=Bluetooth
-Comment=Bluetooth obex
+Name=Bluetooth File Transfer
+Comment=Send and receive files via bluetooth
 Exec=io.elementary.bluetooth
 Icon=io.elementary.bluetooth
 Type=Application


### PR DESCRIPTION
Just only `Bluetooth` is ambiguous so explicit what this app does in the desktop files.