### PR TITLE
Bluetooth in the title case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bluetooth Daemon
 [![Translation status](https://l10n.elementary.io/widget/desktop/bluetooth-daemon/svg-badge.svg)](https://l10n.elementary.io/engage/desktop/)
 
-Send and receive files via bluetooth
+Send and receive files via Bluetooth
 
 ## Building and Installation
 

--- a/data/bluetooth-daemon.desktop
+++ b/data/bluetooth-daemon.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Bluetooth Daemon
-Comment=Send and receive files via bluetooth
+Comment=Send and receive files via Bluetooth
 Exec=io.elementary.bluetooth -s
 Icon=io.elementary.bluetooth
 Type=Application

--- a/data/bluetooth-daemon.metainfo.xml
+++ b/data/bluetooth-daemon.metainfo.xml
@@ -8,9 +8,9 @@
   <compulsory_for_desktop>Pantheon</compulsory_for_desktop>
 
   <name>Bluetooth Daemon</name>
-  <summary>Send and receive files via bluetooth</summary>
+  <summary>Send and receive files via Bluetooth</summary>
   <description>
-    <p>Manages bluetooth settings and provides bluetooth transfer features.</p>
+    <p>Manages Bluetooth settings and provides Bluetooth transfer features.</p>
   </description>
 
   <content_rating type="oars-1.1" />

--- a/data/bluetooth.desktop
+++ b/data/bluetooth.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Bluetooth File Transfer
-Comment=Send and receive files via bluetooth
+Comment=Send and receive files via Bluetooth
 Exec=io.elementary.bluetooth
 Icon=io.elementary.bluetooth
 Type=Application

--- a/data/gschema.xml
+++ b/data/gschema.xml
@@ -9,7 +9,7 @@
     <key type="b" name="confirm-accept-files">
       <default>true</default>
       <summary>Whether to ask user before receiving a file</summary>
-      <description>If set to "true", when an external bluetooth device tries to send a file, the user will be asked to accept or decline it. </description>
+      <description>If set to "true", when an external Bluetooth device tries to send a file, the user will be asked to accept or decline it.</description>
     </key>
   </schema>
 </schemalist>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -23,7 +23,7 @@
 public class BluetoothApp : Gtk.Application {
     public const OptionEntry[] OPTIONS_BLUETOOTH = {
         { "silent", 's', 0, OptionArg.NONE, out silent, "Run the Application in background", null},
-        { "send", 'f', 0, OptionArg.NONE, out send, "Open file to send via bluetooth", null },
+        { "send", 'f', 0, OptionArg.NONE, out send, "Open file to send via Bluetooth", null },
         { "", 0, 0, OptionArg.STRING_ARRAY, out arg_files, "Get files", null },
         { null }
     };


### PR DESCRIPTION
Because Bluetooth is a proper noun.