### PR TITLE
Application: Refactoring

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -23,7 +23,7 @@
 public class BluetoothApp : Gtk.Application {
     public const OptionEntry[] OPTIONS_BLUETOOTH = {
         { "silent", 's', 0, OptionArg.NONE, out silent, "Run the Application in background", null},
-        { "send", 'f', 0, OptionArg.FILENAME_ARRAY, out arg_files, "Open file to send via Bluetooth", "FILE..." },
+        { "send", 'f', 0, OptionArg.FILENAME_ARRAY, out arg_files, "Open file to send via Bluetooth", "FILE…" },
         { null }
     };
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -138,7 +138,7 @@ public class BluetoothApp : Gtk.Application {
             bt_receivers = new GLib.List<BtReceiver> ();
             bt_senders = new GLib.List<BtSender> ();
             object_manager = new Bluetooth.ObjectManager ();
-            object_manager.notify["has-object"].connect (() => {
+            object_manager.notify["has-adapter"].connect (() => {
                 var build_path = Path.build_filename (
                     Environment.get_home_dir (), ".local", "share", "contractor"
                 );
@@ -154,7 +154,7 @@ public class BluetoothApp : Gtk.Application {
                     )
                 );
 
-                if (object_manager.has_object) {
+                if (object_manager.has_adapter) {
                     if (!active_once) {
                         agent_obex = new Bluetooth.Obex.Agent ();
                         agent_obex.transfer_view.connect (dialog_active);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -44,6 +44,7 @@ public class BluetoothApp : Gtk.Application {
         application_id = "io.elementary.bluetooth";
         flags |= ApplicationFlags.HANDLES_COMMAND_LINE;
         Intl.setlocale (LocaleCategory.ALL, "");
+        add_main_option_entries (OPTIONS_BLUETOOTH);
     }
 
     private File[] create_files_for_arg (ApplicationCommandLine command, string[] args) {
@@ -98,16 +99,6 @@ public class BluetoothApp : Gtk.Application {
     }
 
     public override int command_line (ApplicationCommandLine command) {
-        string [] args_cmd = command.get_arguments ();
-        unowned string [] args = args_cmd;
-        var opt_context = new OptionContext (null);
-        opt_context.add_main_entries (OPTIONS_BLUETOOTH, null);
-        try {
-            opt_context.parse (ref args);
-        } catch (Error err) {
-            warning (err.message);
-        }
-
         activate ();
 
         // Handle "send" option

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -47,7 +47,7 @@ public class BluetoothApp : Gtk.Application {
         add_main_option_entries (OPTIONS_BLUETOOTH);
     }
 
-    private File[] create_files_for_arg (ApplicationCommandLine command, string[] args) {
+    private File[] create_files_for_args (ApplicationCommandLine command, string[] args) {
         File[] files = {};
 
         foreach (unowned string arg in args) {
@@ -103,7 +103,7 @@ public class BluetoothApp : Gtk.Application {
 
         // Handle "send" option
         if (arg_files != null) {
-            File[] files = create_files_for_arg (command, arg_files);
+            File[] files = create_files_for_args (command, arg_files);
 
             if (files.length > 0) {
                 scan_and_send_files (files);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -87,8 +87,8 @@ public class BluetoothApp : Gtk.Application {
                 bt_sender.add_files (files, device);
                 bt_senders.append (bt_sender);
                 bt_sender.show_all ();
-                bt_sender.destroy.connect (()=> {
-                    bt_senders.foreach ((sender)=>{
+                bt_sender.destroy.connect (() => {
+                    bt_senders.foreach ((sender) => {
                         if (sender.device == bt_sender.device) {
                             bt_senders.remove_link (bt_senders.find (sender));
                         }
@@ -190,12 +190,12 @@ public class BluetoothApp : Gtk.Application {
     }
 
     private void dialog_active (string session_path) {
-        bt_receivers.foreach ((receiver)=>{
+        bt_receivers.foreach ((receiver) => {
             if (receiver.transfer.session == session_path) {
                 receiver.show_all ();
             }
         });
-        bt_senders.foreach ((sender)=>{
+        bt_senders.foreach ((sender) => {
             if (sender.transfer.session == session_path) {
                 sender.show_all ();
             }
@@ -204,7 +204,7 @@ public class BluetoothApp : Gtk.Application {
 
     private bool insert_sender (File[] files, Bluetooth.Device device) {
         bool exist = false;
-        bt_senders.foreach ((sender)=>{
+        bt_senders.foreach ((sender) => {
             if (sender.device == device) {
                 sender.insert_files (files);
                 sender.present ();
@@ -226,8 +226,8 @@ public class BluetoothApp : Gtk.Application {
 
         bt_receiver = new BtReceiver (this);
         bt_receivers.append (bt_receiver);
-        bt_receiver.destroy.connect (()=> {
-            bt_receivers.foreach ((receiver)=>{
+        bt_receiver.destroy.connect (() => {
+            bt_receivers.foreach ((receiver) => {
                 if (receiver.transfer.session == bt_receiver.session) {
                     bt_receivers.remove_link (bt_receivers.find (receiver));
                 }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -51,14 +51,15 @@ public class BluetoothApp : Gtk.Application {
 
         foreach (unowned string arg in args) {
             var file = command.create_file_for_arg (arg);
-            if (file.query_exists ()) {
-                files += file;
-            } else {
+            if (!file.query_exists ()) {
                 stderr.printf (
-                    "The file %s was not found and will not be sent.\n",
+                    "Ignoring not found file: %s\n",
                     file.get_path ()
                 );
+                continue;
             }
+
+            files += file;
         }
 
         return files;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -23,8 +23,7 @@
 public class BluetoothApp : Gtk.Application {
     public const OptionEntry[] OPTIONS_BLUETOOTH = {
         { "silent", 's', 0, OptionArg.NONE, out silent, "Run the Application in background", null},
-        { "send", 'f', 0, OptionArg.NONE, out send, "Open file to send via Bluetooth", null },
-        { "", 0, 0, OptionArg.STRING_ARRAY, out arg_files, "Get files", null },
+        { "send", 'f', 0, OptionArg.FILENAME_ARRAY, out arg_files, "Open file to send via Bluetooth", "FILE..." },
         { null }
     };
 
@@ -37,10 +36,9 @@ public class BluetoothApp : Gtk.Application {
     public GLib.List<BtReceiver> bt_receivers;
     public GLib.List<BtSender> bt_senders;
     public static bool silent = true;
-    public static bool send = false;
     public static bool active_once;
     [CCode (array_length = false, array_null_terminated = true)]
-    public static string[]? arg_files = {};
+    public static string[]? arg_files = null;
 
     construct {
         application_id = "io.elementary.bluetooth";
@@ -61,7 +59,7 @@ public class BluetoothApp : Gtk.Application {
 
         activate ();
 
-        if (send) {
+        if (arg_files != null) {
             File [] files = {};
             foreach (unowned string arg_file in arg_files) {
                 var file = command.create_file_for_arg (arg_file);
@@ -105,9 +103,6 @@ public class BluetoothApp : Gtk.Application {
                         });
                     }
                 });
-
-                arg_files = {};
-                send = false;
             }
         }
 

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -19,7 +19,7 @@ public class Bluetooth.ObjectManager : Object {
     public signal void device_added (Bluetooth.Device device);
     public signal void device_removed (Bluetooth.Device device);
     public signal void status_discovering ();
-    public bool has_object { get; private set; default = false; }
+    public bool has_adapter { get; private set; default = false; }
     public Settings settings;
     private GLib.DBusObjectManagerClient object_manager;
 
@@ -93,7 +93,7 @@ public class Bluetooth.ObjectManager : Object {
             device_added (device);
         } else if (iface is Bluetooth.Adapter) {
             unowned var adapter = (Bluetooth.Adapter) iface;
-            has_object = true;
+            has_adapter = true;
             ((DBusProxy) adapter).g_properties_changed.connect ((changed, invalid) => {
                 var discovering = changed.lookup_value ("Discovering", GLib.VariantType.BOOLEAN);
                 if (discovering != null) {
@@ -107,7 +107,7 @@ public class Bluetooth.ObjectManager : Object {
         if (iface is Bluetooth.Device) {
             device_removed ((Bluetooth.Device) iface);
         } else if (iface is Bluetooth.Adapter) {
-            has_object = !get_adapters ().is_empty;
+            has_adapter = !get_adapters ().is_empty;
         }
     }
 


### PR DESCRIPTION
- Rename variable `has_object` to `has_adapter` for readability
  - This flag holds whether there is a Bluetooth adapter connected to your device
- Require files for `--send` option
  - Files specified in the command-line argument are only used for this option, so lets make these files designated for this option
-  Split parsing files passed as arguments and sending them into methods
- Treat errors first and use shorten and generalized word for log message
- Use `GLib.Application.add_main_option_entries()` instead of parsing options manually
  - This also prevents the app launched when passing invalid options
- Coding style: Fix missing space `()=>{`→`() => {`