### PR TITLE
Manager: Fix always checking whether the first adapter is discovering

### DIFF
--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -152,11 +152,9 @@ public class Bluetooth.ObjectManager : Object {
     public bool check_discovering () {
         var adapters = get_adapters ();
         foreach (var adapter in adapters) {
-            if (!adapter.discovering) {
-                continue;
+            if (adapter.discovering) {
+                return true;
             }
-
-            return true;
         }
 
         return false;

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -147,11 +147,18 @@ public class Bluetooth.ObjectManager : Object {
             }
         }
     }
+
+    // Check if there is an adapter discovering devices
     public bool check_discovering () {
         var adapters = get_adapters ();
         foreach (var adapter in adapters) {
-            return adapter.discovering;
+            if (!adapter.discovering) {
+                continue;
+            }
+
+            return true;
         }
+
         return false;
     }
 


### PR DESCRIPTION
The previous code always returns whether the first adapter in the list is discovering or not, while the code seems to be intended to iterate the list.