### PR TITLE
ObjectManager: Refactoring

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -270,7 +270,8 @@ public class BluetoothApp : Gtk.Application {
             return;
         }
 
-        if (object_manager.settings.get_boolean ("confirm-accept-files")) {
+        var settings = new Settings ("io.elementary.desktop.bluetooth");
+        if (settings.get_boolean ("confirm-accept-files")) {
             notification.set_priority (NotificationPriority.URGENT);
             notification.set_title (_("Incoming file"));
             notification.set_body (

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -161,7 +161,7 @@ public class Bluetooth.ObjectManager : Object {
         return (owned) adapters;
     }
 
-    public Gee.Collection<Bluetooth.Device> get_devices () requires (object_manager != null) {
+    public Gee.LinkedList<Bluetooth.Device> get_devices () requires (object_manager != null) {
         var devices = new Gee.LinkedList<Bluetooth.Device> ();
         object_manager.get_objects ().foreach ((object) => {
             GLib.DBusInterface? iface = object.get_interface ("org.bluez.Device1");
@@ -174,6 +174,7 @@ public class Bluetooth.ObjectManager : Object {
 
         return (owned) devices;
     }
+
     public async void start_discovery () {
         var adapters = get_adapters ();
         foreach (var adapter in adapters) {

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -20,7 +20,7 @@ public class Bluetooth.ObjectManager : Object {
     public signal void device_removed (Bluetooth.Device device);
     public signal void status_discovering ();
     public bool has_adapter { get; private set; default = false; }
-    public Settings settings;
+    private Settings settings;
     private GLib.DBusObjectManagerClient object_manager;
 
     construct {

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -27,7 +27,9 @@ public class Bluetooth.ObjectManager : Object {
 
     construct {
         settings = new Settings ("io.elementary.desktop.bluetooth");
+
         create_manager.begin ();
+
         settings.changed ["sharing"].connect (() => {
             if (settings.get_boolean ("sharing")) {
                 register_agent ();
@@ -95,7 +97,7 @@ public class Bluetooth.ObjectManager : Object {
                 "/org/bluez/obex",
                 "org.bluez.obex.AgentManager1",
                 "RegisterAgent",
-                new Variant ("(o)", "/org/bluez/obex/elementary"),
+                new Variant ("(o)", Obex.Agent.AGENT_OBJECT_PATH),
                 null,
                 GLib.DBusCallFlags.NONE,
                 -1
@@ -113,7 +115,7 @@ public class Bluetooth.ObjectManager : Object {
                 "/org/bluez/obex",
                 "org.bluez.obex.AgentManager1",
                 "UnregisterAgent",
-                new Variant ("(o)", "/org/bluez/obex/elementary"),
+                new Variant ("(o)", Obex.Agent.AGENT_OBJECT_PATH),
                 null,
                 GLib.DBusCallFlags.NONE,
                 -1

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -151,8 +151,9 @@ public class Bluetooth.ObjectManager : Object {
         var adapters = new Gee.LinkedList<Bluetooth.Adapter> ();
         object_manager.get_objects ().foreach ((object) => {
             GLib.DBusInterface? iface = object.get_interface ("org.bluez.Adapter1");
-            if (iface == null)
+            if (iface == null) {
                 return;
+            }
 
             adapters.add (((Bluetooth.Adapter) iface));
         });
@@ -164,8 +165,9 @@ public class Bluetooth.ObjectManager : Object {
         var devices = new Gee.LinkedList<Bluetooth.Device> ();
         object_manager.get_objects ().foreach ((object) => {
             GLib.DBusInterface? iface = object.get_interface ("org.bluez.Device1");
-            if (iface == null)
+            if (iface == null) {
                 return;
+            }
 
             devices.add (((Bluetooth.Device) iface));
         });

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -215,11 +215,11 @@ public class Bluetooth.ObjectManager : Object {
 
     public Bluetooth.Adapter? get_adapter_from_path (string path) {
         GLib.DBusObject? object = object_manager.get_object (path);
-        if (object != null) {
-            return (Bluetooth.Adapter?) object.get_interface ("org.bluez.Adapter1");
+        if (object == null) {
+            return null;
         }
 
-        return null;
+        return (Bluetooth.Adapter?) object.get_interface ("org.bluez.Adapter1");
     }
 
     public Bluetooth.Device? get_device (string address) {
@@ -229,6 +229,7 @@ public class Bluetooth.ObjectManager : Object {
                 return device;
             }
         }
+
         return null;
     }
 }

--- a/src/Services/ObexAgent.vala
+++ b/src/Services/ObexAgent.vala
@@ -32,6 +32,9 @@ public class Bluetooth.Obex.Agent : GLib.Object {
     public signal void response_accepted (string address, GLib.ObjectPath objectpath);
     public signal void transfer_view (string session_path);
     public signal void response_canceled ();
+
+    public const string AGENT_OBJECT_PATH = "/org/bluez/obex/elementary";
+
     /*one confirmation for many files in one session */
     private GLib.ObjectPath many_files;
 
@@ -42,7 +45,7 @@ public class Bluetooth.Obex.Agent : GLib.Object {
             GLib.BusNameOwnerFlags.NONE,
             (conn)=>{
                 try {
-                    conn.register_object ("/org/bluez/obex/elementary", this);
+                    conn.register_object (AGENT_OBJECT_PATH, this);
                 } catch (Error e) {
                     error (e.message);
                 }


### PR DESCRIPTION
- Lessen scope of settings
- Rename and separate `obex_agentmanager ()` for readability
- Fix long line
- Make the object path `/org/bluez/obex/elementary` constant of `Obex.Agent` class so that we can understand where this object path comes from
- Explicit if brackets
- Fix returning in a type of super class `Gee.Collection` instead of its own class `Gee.LinkedList` unintentionally
- Return errors first
- Add some newlines for readability
