### PR TITLE
Fix crash when sending file from terminal; Silence some warnings

### DIFF
--- a/src/Dialog/BtScan.vala
+++ b/src/Dialog/BtScan.vala
@@ -112,13 +112,15 @@ public class BtScan : Granite.Dialog {
             destroy ();
         });
     }
-    public override void show () {
-        base.show ();
+
+    public void init () {
         var devices = manager.get_devices ();
         foreach (var device in devices) {
             add_device (device);
         }
-        manager.start_discovery.begin ();
+        manager.start_discovery.begin (() => {
+            show_all ();
+        });
     }
 
     private void add_device (Bluetooth.Device device) {

--- a/src/Dialog/BtSender.vala
+++ b/src/Dialog/BtSender.vala
@@ -148,7 +148,7 @@ public class BtSender : Granite.Dialog {
         });
     }
 
-    public void add_files (File [] files, Bluetooth.Device device) {
+    public void add_files (Gee.ArrayList<File> files, Bluetooth.Device device) {
         foreach (var file in files) {
             Gtk.TreeIter iter;
             liststore.append (out iter);
@@ -164,7 +164,7 @@ public class BtSender : Granite.Dialog {
         create_session.begin ();
     }
 
-    public void insert_files (File [] files) {
+    public void insert_files (Gee.ArrayList<File> files) {
         foreach (var file in files) {
             bool exist = false;
             liststore.foreach ((model, path, iter) => {

--- a/src/Services/Manager.vala
+++ b/src/Services/Manager.vala
@@ -21,6 +21,7 @@ public class Bluetooth.ObjectManager : Object {
     public signal void status_discovering ();
 
     public bool has_adapter { get; private set; default = false; }
+    public bool ready { get; private set; default = false; }
 
     private Settings settings;
     private GLib.DBusObjectManagerClient object_manager;
@@ -28,7 +29,9 @@ public class Bluetooth.ObjectManager : Object {
     construct {
         settings = new Settings ("io.elementary.desktop.bluetooth");
 
-        create_manager.begin ();
+        create_manager.begin (() => {
+            ready = true;
+        });
 
         settings.changed ["sharing"].connect (() => {
             if (settings.get_boolean ("sharing")) {


### PR DESCRIPTION
 - Use Gee.ArrayList instead of File[] - this stopped the crash
 - Ensure the ObjectManager has finished initializing before sending files. This ensures certain functions' requirements are met before they are called

This makes the `scan_and_send_files` function wait in Idle loop until `object_manager` flags it is ready - is there a more elegant way?